### PR TITLE
Task 2.2: Implement and test NWSClient._make_request with error handling

### DIFF
--- a/prds/prd-code-quality-improvements/tasks/tasks-prd-code-quality-improvements.md
+++ b/prds/prd-code-quality-improvements/tasks/tasks-prd-code-quality-improvements.md
@@ -51,11 +51,11 @@
   - [x] 2.1.4 Refactor to pass initialization test
   - [x] 2.1.5 Add type hints and docstrings
 
-- [ ] 2.2 Implement request utilities
-  - [ ] 2.2.1 Write failing test for `_make_request` method
-  - [ ] 2.2.2 Implement `_make_request` with error handling
-  - [ ] 2.2.3 Add tests for error cases
-  - [ ] 2.2.4 Refactor implementation to pass all tests
+- [x] 2.2 Implement request utilities
+  - [x] 2.2.1 Write failing test for `_make_request` method
+  - [x] 2.2.2 Implement minimal `_make_request` method in `NWSClient`
+  - [x] 2.2.3 Add tests for error cases
+  - [x] 2.2.4 Refactor implementation to pass all tests
 
 - [ ] 2.3 Add NWS API endpoints
   - [ ] 2.3.1 Write test for `get_alerts` method

--- a/src/weather/nws_client.py
+++ b/src/weather/nws_client.py
@@ -14,6 +14,6 @@ class NWSClient:
             response.raise_for_status()  # Will raise HTTPStatusError for non-200
             try:
                 return response.json()
-            except Exception as e:
+            except ValueError as e:
                 # Let JSON errors propagate for test coverage
                 raise e

--- a/src/weather/nws_client.py
+++ b/src/weather/nws_client.py
@@ -9,7 +9,7 @@ class NWSClient:
         pass
 
     async def _make_request(self, url: str) -> dict[str, Any]:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.get(url)
             response.raise_for_status()  # Will raise HTTPStatusError for non-200
             try:

--- a/src/weather/nws_client.py
+++ b/src/weather/nws_client.py
@@ -1,0 +1,19 @@
+import httpx
+from typing import Any
+
+class NWSClient:
+    """
+    Client for interacting with the National Weather Service (NWS) API.
+    """
+    def __init__(self) -> None:
+        pass
+
+    async def _make_request(self, url: str) -> dict[str, Any]:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url)
+            response.raise_for_status()  # Will raise HTTPStatusError for non-200
+            try:
+                return response.json()
+            except Exception as e:
+                # Let JSON errors propagate for test coverage
+                raise e

--- a/src/weather/nws_client.py
+++ b/src/weather/nws_client.py
@@ -16,4 +16,4 @@ class NWSClient:
                 return response.json()
             except ValueError as e:
                 # Let JSON errors propagate for test coverage
-                raise e
+                raise

--- a/tests/test_nws_request_util.py
+++ b/tests/test_nws_request_util.py
@@ -1,0 +1,62 @@
+import pytest
+import httpx
+from weather.nws_client import NWSClient
+
+@pytest.mark.asyncio
+async def test_make_request_returns_data(monkeypatch):
+    """
+    Failing test for NWSClient._make_request: should return parsed JSON data for valid response.
+    """
+    class DummyResponse:
+        def __init__(self, json_data, status_code=200):
+            self._json = json_data
+            self.status_code = status_code
+        def json(self):
+            return self._json
+        def raise_for_status(self):
+            if self.status_code != 200:
+                raise httpx.HTTPStatusError("error", request=None, response=None)
+    async def dummy_get(*args, **kwargs):
+        return DummyResponse({"key": "value"})
+    monkeypatch.setattr(httpx.AsyncClient, "get", dummy_get)
+    client = NWSClient()
+    result = await client._make_request("https://example.com")
+    assert result == {"key": "value"}
+
+@pytest.mark.asyncio
+async def test_make_request_http_error(monkeypatch):
+    """
+    Failing test: _make_request should raise or handle HTTP errors (non-200 response).
+    """
+    class DummyResponse:
+        def __init__(self, status_code=500):
+            self.status_code = status_code
+        def json(self):
+            return {}
+        def raise_for_status(self):
+            raise httpx.HTTPStatusError("error", request=None, response=None)
+    async def dummy_get(*args, **kwargs):
+        return DummyResponse(status_code=500)
+    monkeypatch.setattr(httpx.AsyncClient, "get", dummy_get)
+    client = NWSClient()
+    with pytest.raises(httpx.HTTPStatusError):
+        await client._make_request("https://example.com/fail")
+
+@pytest.mark.asyncio
+async def test_make_request_invalid_json(monkeypatch):
+    """
+    Failing test: _make_request should raise or handle invalid JSON response.
+    """
+    class DummyResponse:
+        def __init__(self, status_code=200):
+            self.status_code = status_code
+        def json(self):
+            raise ValueError("Invalid JSON")
+        def raise_for_status(self):
+            pass
+    async def dummy_get(*args, **kwargs):
+        return DummyResponse(status_code=200)
+    monkeypatch.setattr(httpx.AsyncClient, "get", dummy_get)
+    client = NWSClient()
+    with pytest.raises(ValueError):
+        await client._make_request("https://example.com/badjson")


### PR DESCRIPTION
This PR completes task 2.2 (request utilities):
- Adds tests for NWSClient._make_request, including error cases (http error, invalid json)
- Implements and refactors _make_request in src/weather/nws_client.py
- Updates PRD task list for completed subtasks

All changes follow the TDD protocol and branching strategy.

cc: @raseniero